### PR TITLE
24 weak networks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: PlackettLuce
 Type: Package
 Title: Plackett-Luce Models for Rankings
-Version: 0.4.0
+Version: 0.4.0.9000
 Authors@R: c(person("Heather", "Turner",
         email = "ht@heatherturner.net", role = c("aut", "cre"),
         comment = c(ORCID = "0000-0002-1256-3375")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# PlackettLuce (development version)
+
+* Avoid computing variance-covariance matrix in `predict.PLADMM(vcov = FALSE)` and `AIC` when new data specified.
+
 # PlackettLuce 0.4.0
 
 * New `pladmm` function to fit the Plackett-Luce model with log-worth modelled by item covariates.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # PlackettLuce (development version)
 
-* Avoid computing variance-covariance matrix in `predict.PLADMM(vcov = FALSE)` and `AIC` when new data specified.
+* Avoid computing variance-covariance matrix in `predict.PLADMM(vcov = FALSE)` and `AIC` when new data specified (partial fix to #50).
 
 # PlackettLuce 0.4.0
 

--- a/R/pltree-summaries.R
+++ b/R/pltree-summaries.R
@@ -134,7 +134,7 @@ AIC.pltree <- function(object, newdata = NULL, ...) {
                                          newdata = newdata,
                                          type = "node")
     # set up to refit models based on newdata
-    cf <- itempar(object)
+    cf <- coef(object, log = FALSE)
     if (is.null(dim(cf))) cf <- t(as.matrix(cf))
     nodes <- partykit::nodeids(object, terminal = TRUE)
     dots <- object$info$dots

--- a/R/predict.R
+++ b/R/predict.R
@@ -8,7 +8,7 @@ predict.PLADMM <- function(object, newdata = NULL,
     type <- match.arg(type)
     # if newdata, create new X matrix
     if (!is.null(newdata)){
-        object$vcov <- vcov(object) # vcov based on original X matrix
+        if (se.fit) object$vcov <- vcov(object) # vcov based on original X matrix
         # allow for missing factor levels (avoid terms etc for now)
         X <- matrix(0, nrow = nrow(newdata), ncol = ncol(object$x),
                     dimnames = list(seq(nrow(newdata)), colnames(object$x)))


### PR DESCRIPTION
A partial fix to #50, by avoiding the computation of the variance-covariance matrix in AIC when not needed (also avoided unnecessary computation of vcov in predict.PLADMM).